### PR TITLE
Add gsc.excludePaths setting for glob-based file exclusion

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,11 @@
       "version": "0.3.0",
       "license": "LGPL-3.0-or-later",
       "dependencies": {
+        "minimatch": "^10.2.4",
         "semver": "^7.6.3"
       },
       "devDependencies": {
+        "@types/minimatch": "^5.1.2",
         "@types/mocha": "^10.0.9",
         "@types/node": "20.x",
         "@types/semver": "^7.5.8",
@@ -385,6 +387,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/minimatch": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.2.tgz",
+      "integrity": "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/mocha": {
       "version": "10.0.9",
       "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.9.tgz",
@@ -565,6 +574,22 @@
         }
       }
     },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/@typescript-eslint/utils": {
       "version": "8.13.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.13.0.tgz",
@@ -628,6 +653,22 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@vscode/test-cli/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@vscode/test-electron": {
@@ -829,9 +870,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1672,6 +1713,22 @@
         "node": ">= 6"
       }
     },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/globals": {
       "version": "14.0.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
@@ -2191,19 +2248,39 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-      "dev": true,
-      "license": "ISC",
+      "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^5.0.2"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.17"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minimatch/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/minimatch/node_modules/brace-expansion": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
+      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/minipass": {

--- a/package.json
+++ b/package.json
@@ -156,6 +156,15 @@
           "description": "An array of file paths that will be ignored during error diagnostics (case insensitive). For example: `maps\\mp\\gametypes\\ignoredScript`",
           "scope": "resource"
         },
+        "gsc.excludePaths": {
+          "type": "array",
+          "default": [],
+          "items": {
+            "type": "string"
+          },
+          "description": "An array of glob patterns for file paths that should be completely excluded from parsing. Matched files are never loaded into memory. Useful for large workspaces where you want to skip entire folders. For example: `**/raw/animtrees/**`, `**/raw/xanim/**`",
+          "scope": "resource"
+        },
         "gsc.includedWorkspaceFolders": {
           "type": "array",
           "default": [],
@@ -177,6 +186,7 @@
     "test": "vscode-test"
   },
   "devDependencies": {
+    "@types/minimatch": "^5.1.2",
     "@types/mocha": "^10.0.9",
     "@types/node": "20.x",
     "@types/semver": "^7.5.8",
@@ -189,6 +199,7 @@
     "typescript": "^5.6.3"
   },
   "dependencies": {
+    "minimatch": "^10.2.4",
     "semver": "^7.6.3"
   }
 }

--- a/src/GscConfig.ts
+++ b/src/GscConfig.ts
@@ -128,7 +128,10 @@ export class GscConfig {
 		if (e.affectsConfiguration('gsc')) {
 			LoggerOutput.log("[GscConfig] GSC configuration changed.");
 
+			const excludePathsChanged = e.affectsConfiguration('gsc.excludePaths');
+
 			// 1. Load new configuration for each workspace and assign it to cached files
+			// This also evicts now-excluded files from cache
 			GscFiles.updateConfigurationOfCachedFiles();
 
 			// 2. Update tree view
@@ -137,8 +140,14 @@ export class GscConfig {
 			// 3. Update status bar in case the game has changed
 			await GscStatusBar.updateStatusBar("configChanged");
 
-			// 4. Update diagnostics for all files with new configuration
-			await GscDiagnosticsCollection.updateDiagnosticsForAll("config changed");
+			// 4. If excludePaths changed, re-parse all files to pick up newly un-excluded files
+			if (excludePathsChanged) {
+				LoggerOutput.log("[GscConfig] excludePaths changed, re-parsing all files.");
+				await GscFiles.parseAllFiles();
+			} else {
+				// 5. Update diagnostics for all files with new configuration
+				await GscDiagnosticsCollection.updateDiagnosticsForAll("config changed");
+			}
 		}
 	}
 
@@ -213,6 +222,15 @@ export class GscConfig {
 		return config.update('ignoredFilePaths', ignoredFilePaths, vscode.ConfigurationTarget.WorkspaceFolder);
 	}
 
+
+	/**
+	 * Get array of exclude path glob patterns
+	 */
+	public static getExcludePaths(uri: vscode.Uri): string[] {
+		const config = vscode.workspace.getConfiguration('gsc', uri);
+		const excludePaths: string[] = config.get('excludePaths', []);
+		return excludePaths;
+	}
 
 	public static getErrorDiagnostics(uri: vscode.Uri): ConfigErrorDiagnostics {
 		// Load ignored function names

--- a/src/GscFile.ts
+++ b/src/GscFile.ts
@@ -52,6 +52,7 @@ export class GscFile {
                 currentGame: GscGame.UniversalGame,
                 ignoredFunctionNames: [],
                 ignoredFilePaths: [],
+                excludePaths: [],
                 errorDiagnostics: ConfigErrorDiagnostics.Enable,
                 gameConfig: GscConfig.gamesConfigs.get(GscGame.UniversalGame)!
             };

--- a/src/GscFileCache.ts
+++ b/src/GscFileCache.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import * as os from 'os';
+import { minimatch } from 'minimatch';
 import { GscFile } from './GscFile';
 import { GscFiles } from './GscFiles';
 import { ConfigErrorDiagnostics, GscConfig, GscGame, GscGameConfig, GscGameRootFolder } from './GscConfig';
@@ -21,6 +22,8 @@ export type GscFilesConfig = {
     ignoredFunctionNames: string[];
     /** Ignored file paths */
     ignoredFilePaths: string[];
+    /** Glob patterns for paths to completely exclude from parsing */
+    excludePaths: string[];
     /** Currently selected game */
     currentGame: GscGame;
     /** Mode of diagnostics collection */
@@ -211,7 +214,24 @@ export class GscWorkspaceFileData {
     }
 
     updateConfiguration() {
+        const oldExcludePaths = this.config.excludePaths;
         this.config = GscWorkspaceFileData.loadConfig(this.workspaceFolder);
+
+        // Evict files that are now excluded by the updated config
+        const newExcludePaths = this.config.excludePaths;
+        if (JSON.stringify(oldExcludePaths) !== JSON.stringify(newExcludePaths) && newExcludePaths.length > 0) {
+            const filesToRemove: vscode.Uri[] = [];
+            for (const file of this.parsedFiles.values()) {
+                const relativePath = vscode.workspace.asRelativePath(file.uri, false);
+                if (GscWorkspaceFileData.isFileExcluded(relativePath, newExcludePaths)) {
+                    filesToRemove.push(file.uri);
+                }
+            }
+            for (const uri of filesToRemove) {
+                LoggerOutput.log("[GscFileCache] Evicting now-excluded file from cache", vscode.workspace.asRelativePath(uri));
+                this.removeParsedFile(uri);
+            }
+        }
 
         // Loop all GscFile and update their configuration
         for (const file of this.parsedFiles.values()) {
@@ -219,6 +239,29 @@ export class GscWorkspaceFileData {
 
             file.gamePath = GscFiles.getGamePathFromGscFile(file);
         }
+    }
+
+    /**
+     * Check if a file path matches any of the exclude glob patterns.
+     * @param relativePath The workspace-relative path of the file (forward slashes).
+     * @param excludePaths Array of glob patterns to check against.
+     */
+    public static isFileExcluded(relativePath: string, excludePaths: string[]): boolean {
+        if (excludePaths.length === 0) {
+            return false;
+        }
+        // Normalize to forward slashes for consistent matching
+        const normalized = relativePath.replace(/\\/g, '/');
+        for (const pattern of excludePaths) {
+            try {
+                if (minimatch(normalized, pattern, { dot: true, nocase: true })) {
+                    return true;
+                }
+            } catch {
+                // Malformed glob pattern - skip it silently
+            }
+        }
+        return false;
     }
 
 
@@ -235,8 +278,9 @@ export class GscWorkspaceFileData {
             rootFolder: GscConfig.getGameRootFolder(workspaceFolder.uri), 
             currentGame: currentGame, 
             ignoredFunctionNames: GscConfig.getIgnoredFunctionNames(workspaceFolder.uri), 
-            ignoredFilePaths: GscConfig.getIgnoredFilePaths(workspaceFolder.uri), 
-            errorDiagnostics: GscConfig.getErrorDiagnostics(workspaceFolder.uri), 
+            ignoredFilePaths: GscConfig.getIgnoredFilePaths(workspaceFolder.uri),
+            excludePaths: GscConfig.getExcludePaths(workspaceFolder.uri),
+            errorDiagnostics: GscConfig.getErrorDiagnostics(workspaceFolder.uri),
             gameConfig: GscConfig.gamesConfigs.get(currentGame)!
         };
     }

--- a/src/GscFiles.ts
+++ b/src/GscFiles.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import * as fs from 'fs';
 import * as path from 'path';
 import { GscFileParser, GscData, GroupType } from './GscFileParser';
-import { GscCachedFilesPerWorkspace } from './GscFileCache';
+import { GscCachedFilesPerWorkspace, GscWorkspaceFileData } from './GscFileCache';
 import { GscFile } from './GscFile';
 import { GscConfig, GscGameRootFolder } from './GscConfig';
 import { LoggerOutput } from './LoggerOutput';
@@ -79,8 +79,21 @@ export class GscFiles {
         // Get workspace folder where the file is located
         const workspaceFolder = vscode.workspace.getWorkspaceFolder(fileUri);
 
+        // Check if the file is excluded by excludePaths before doing any work
+        if (workspaceFolder) {
+            const excludePaths = GscConfig.getExcludePaths(workspaceFolder.uri);
+            if (excludePaths.length > 0) {
+                const relativePath = vscode.workspace.asRelativePath(fileUri, false);
+                if (GscWorkspaceFileData.isFileExcluded(relativePath, excludePaths)) {
+                    LoggerOutput.log("[GscFiles] File excluded via excludePaths, skipping", vscode.workspace.asRelativePath(fileUri));
+                    const gsc = GscFileParser.parse("");
+                    return new GscFile(gsc, fileUri, workspaceFolder, -1);
+                }
+            }
+        }
+
         LoggerOutput.log("[GscFiles] Getting parsed data of file... (" + reason + ")", vscode.workspace.asRelativePath(fileUri));
-        
+
 
         // This file is not part of workspace, return it and do not cache it
         if (workspaceFolder === undefined) {
@@ -173,6 +186,22 @@ export class GscFiles {
 
         // Find all GSC files in the specified workspace folder or in the entire repository
         var files = await vscode.workspace.findFiles(searchPattern);
+
+        // Filter out files matching excludePaths glob patterns
+        const totalBeforeExclude = files.length;
+        files = files.filter(file => {
+            const ws = vscode.workspace.getWorkspaceFolder(file);
+            if (!ws) { return true; }
+            const excludePaths = GscConfig.getExcludePaths(ws.uri);
+            if (excludePaths.length === 0) { return true; }
+            const relativePath = vscode.workspace.asRelativePath(file, false);
+            const excluded = GscWorkspaceFileData.isFileExcluded(relativePath, excludePaths);
+            if (excluded) {
+                LoggerOutput.log("[GscFiles] Excluded by excludePaths: " + relativePath);
+            }
+            return !excluded;
+        });
+        LoggerOutput.log("[GscFiles] excludePaths filter: " + totalBeforeExclude + " found, " + (totalBeforeExclude - files.length) + " excluded, " + files.length + " will be parsed");
 
         const poolSize = 4; // Number of files to parse concurrently
         let i = 0;
@@ -697,6 +726,21 @@ export class GscFiles {
             // Notify about change
             Events.FileSystemChanged(type, uri, manual);
 
+            // Skip excluded files early (but allow deletes so cache stays clean)
+            if (type !== "delete") {
+                const ws = vscode.workspace.getWorkspaceFolder(uri);
+                if (ws) {
+                    const excludePaths = GscConfig.getExcludePaths(ws.uri);
+                    if (excludePaths.length > 0) {
+                        const relativePath = vscode.workspace.asRelativePath(uri, false);
+                        if (GscWorkspaceFileData.isFileExcluded(relativePath, excludePaths)) {
+                            LoggerOutput.logFile("[GscFiles] File excluded via excludePaths, ignoring " + type, vscode.workspace.asRelativePath(uri));
+                            return;
+                        }
+                    }
+                }
+            }
+
             // Delete of file / directory
             if (type === "delete") {
                 LoggerOutput.logFile("[GscFiles] Detected '" + type + "' of file / folder", vscode.workspace.asRelativePath(uri));
@@ -853,6 +897,18 @@ export class GscFiles {
         // Check if the file is GSC file
         if (!GscFiles.isValidGscFile(uri.fsPath)) {
             return;
+        }
+
+        // Check if the file is excluded via excludePaths
+        const ws = vscode.workspace.getWorkspaceFolder(uri);
+        if (ws) {
+            const excludePaths = GscConfig.getExcludePaths(ws.uri);
+            if (excludePaths.length > 0) {
+                const relativePath = vscode.workspace.asRelativePath(uri, false);
+                if (GscWorkspaceFileData.isFileExcluded(relativePath, excludePaths)) {
+                    return;
+                }
+            }
         }
 
         LoggerOutput.log("[GscFiles] Document changed", vscode.workspace.asRelativePath(uri));

--- a/src/test/workspace/GscExcludePaths.test.ts
+++ b/src/test/workspace/GscExcludePaths.test.ts
@@ -1,0 +1,223 @@
+import * as vscode from 'vscode';
+import * as tests from '../Tests.test';
+import assert from 'assert';
+import { GscFiles } from '../../GscFiles';
+import { GscWorkspaceFileData } from '../../GscFileCache';
+import { LoggerOutput } from '../../LoggerOutput';
+import { Issues } from '../../Issues';
+import { GscConfig } from '../../GscConfig';
+
+
+suite('GscExcludePaths', () => {
+
+    setup(async () => {
+        await tests.activateExtension();
+    });
+
+
+    // ---------------------------------------------------------------
+    // Unit tests for isFileExcluded (pure logic, no VS Code APIs)
+    // ---------------------------------------------------------------
+
+    test('isFileExcluded - matches glob patterns', () => {
+        const patterns = ['**/excluded_folder/**', '**/animtrees/**'];
+
+        // Should be excluded
+        assert.strictEqual(GscWorkspaceFileData.isFileExcluded('excluded_folder/should_be_excluded.gsc', patterns), true);
+        assert.strictEqual(GscWorkspaceFileData.isFileExcluded('GscExcludePaths/excluded_folder/should_be_excluded.gsc', patterns), true);
+        assert.strictEqual(GscWorkspaceFileData.isFileExcluded('animtrees/tree1.gsc', patterns), true);
+        assert.strictEqual(GscWorkspaceFileData.isFileExcluded('GscExcludePaths/animtrees/tree1.gsc', patterns), true);
+
+        // Should NOT be excluded
+        assert.strictEqual(GscWorkspaceFileData.isFileExcluded('scripts/included.gsc', patterns), false);
+        assert.strictEqual(GscWorkspaceFileData.isFileExcluded('GscExcludePaths/scripts/included.gsc', patterns), false);
+        assert.strictEqual(GscWorkspaceFileData.isFileExcluded('scripts/also_included.gsc', patterns), false);
+    });
+
+    test('isFileExcluded - empty patterns excludes nothing', () => {
+        assert.strictEqual(GscWorkspaceFileData.isFileExcluded('anything/file.gsc', []), false);
+    });
+
+    test('isFileExcluded - case insensitive', () => {
+        const patterns = ['**/Excluded_Folder/**'];
+        assert.strictEqual(GscWorkspaceFileData.isFileExcluded('excluded_folder/file.gsc', patterns), true);
+        assert.strictEqual(GscWorkspaceFileData.isFileExcluded('EXCLUDED_FOLDER/file.gsc', patterns), true);
+    });
+
+    test('isFileExcluded - backslash normalization', () => {
+        const patterns = ['**/excluded_folder/**'];
+        // Backslashes in path should be normalized to forward slashes before matching
+        assert.strictEqual(GscWorkspaceFileData.isFileExcluded('GscExcludePaths\\excluded_folder\\file.gsc', patterns), true);
+    });
+
+    test('isFileExcluded - malformed pattern does not throw', () => {
+        const patterns = ['[invalid-glob'];
+        // Should not throw, just return false
+        assert.strictEqual(GscWorkspaceFileData.isFileExcluded('some/file.gsc', patterns), false);
+    });
+
+
+    // ---------------------------------------------------------------
+    // Integration tests - verify excluded files are not in the cache
+    // ---------------------------------------------------------------
+
+    test('excluded files are not cached on startup', async () => {
+        try {
+            LoggerOutput.log("[Tests][GscExcludePaths] excluded files not cached - start");
+
+            const workspaceUri = tests.filePathToUri('GscExcludePaths');
+
+            // Get all cached files for the GscExcludePaths workspace
+            const cachedFiles = GscFiles.getCachedFiles([workspaceUri]);
+            const cachedPaths = cachedFiles.map(f => vscode.workspace.asRelativePath(f.uri));
+
+            LoggerOutput.log("[Tests][GscExcludePaths] cached files: " + cachedPaths.join(', '));
+
+            // Included files should be in cache
+            assert.ok(
+                cachedPaths.some(p => p.includes('scripts/included.gsc')),
+                "scripts/included.gsc should be cached. Cached: " + cachedPaths.join(', ')
+            );
+            assert.ok(
+                cachedPaths.some(p => p.includes('scripts/also_included.gsc')),
+                "scripts/also_included.gsc should be cached. Cached: " + cachedPaths.join(', ')
+            );
+
+            // Excluded files should NOT be in cache
+            assert.ok(
+                !cachedPaths.some(p => p.includes('excluded_folder/should_be_excluded.gsc')),
+                "excluded_folder/should_be_excluded.gsc should NOT be cached. Cached: " + cachedPaths.join(', ')
+            );
+            assert.ok(
+                !cachedPaths.some(p => p.includes('animtrees/tree1.gsc')),
+                "animtrees/tree1.gsc should NOT be cached. Cached: " + cachedPaths.join(', ')
+            );
+
+            // Exactly 2 files should be cached
+            assert.strictEqual(cachedFiles.length, 2, "Expected 2 cached files, got " + cachedFiles.length + ": " + cachedPaths.join(', '));
+
+            LoggerOutput.log("[Tests][GscExcludePaths] excluded files not cached - done");
+
+            Issues.checkForNewError();
+        } catch (error) {
+            tests.printDebugInfoForError(error);
+        }
+    });
+
+
+    test('creating file in excluded folder does not cache it', async () => {
+        try {
+            LoggerOutput.log("[Tests][GscExcludePaths] create in excluded folder - start");
+
+            const workspaceUri = tests.filePathToUri('GscExcludePaths');
+
+            // Baseline: should have 2 cached files
+            const cachedBefore = GscFiles.getCachedFiles([workspaceUri]);
+            assert.strictEqual(cachedBefore.length, 2, "Baseline: expected 2 cached files");
+
+            // Create a new file in the excluded folder
+            const newFileUri = tests.filePathToUri('GscExcludePaths', 'excluded_folder', 'new_excluded.gsc');
+            await vscode.workspace.fs.writeFile(newFileUri, new TextEncoder().encode("newExcludedFunc() { err }"));
+
+            // Wait for the file system event to propagate
+            await tests.waitForFileSystemChange("create", newFileUri);
+
+            // Small delay to let any debounced processing finish
+            await tests.sleep(500);
+
+            // Cache should still have only 2 files
+            const cachedAfter = GscFiles.getCachedFiles([workspaceUri]);
+            const cachedPathsAfter = cachedAfter.map(f => vscode.workspace.asRelativePath(f.uri));
+
+            assert.ok(
+                !cachedPathsAfter.some(p => p.includes('new_excluded.gsc')),
+                "new_excluded.gsc should NOT be cached. Cached: " + cachedPathsAfter.join(', ')
+            );
+            assert.strictEqual(cachedAfter.length, 2, "Expected 2 cached files after creating excluded file, got " + cachedAfter.length + ": " + cachedPathsAfter.join(', '));
+
+            // Cleanup
+            await vscode.workspace.fs.delete(newFileUri);
+            await tests.waitForFileSystemChange("delete", newFileUri);
+
+            LoggerOutput.log("[Tests][GscExcludePaths] create in excluded folder - done");
+
+            Issues.checkForNewError();
+        } catch (error) {
+            tests.printDebugInfoForError(error);
+        }
+    });
+
+
+    test('creating file in included folder does cache it', async () => {
+        try {
+            LoggerOutput.log("[Tests][GscExcludePaths] create in included folder - start");
+
+            const workspaceUri = tests.filePathToUri('GscExcludePaths');
+
+            // Baseline
+            const cachedBefore = GscFiles.getCachedFiles([workspaceUri]);
+            assert.strictEqual(cachedBefore.length, 2, "Baseline: expected 2 cached files");
+
+            // Create a new file in a non-excluded folder
+            const newFileUri = tests.filePathToUri('GscExcludePaths', 'scripts', 'new_included.gsc');
+            void vscode.workspace.fs.writeFile(newFileUri, new TextEncoder().encode("newIncludedFunc() { err_new }"));
+
+            // Wait for diagnostics which means the file was parsed and cached
+            await tests.waitForDiagnosticsChange(newFileUri, "create included file");
+
+            // Cache should now have 3 files
+            const cachedAfter = GscFiles.getCachedFiles([workspaceUri]);
+            const cachedPathsAfter = cachedAfter.map(f => vscode.workspace.asRelativePath(f.uri));
+
+            assert.ok(
+                cachedPathsAfter.some(p => p.includes('scripts/new_included.gsc')),
+                "scripts/new_included.gsc should be cached. Cached: " + cachedPathsAfter.join(', ')
+            );
+            assert.strictEqual(cachedAfter.length, 3, "Expected 3 cached files after creating included file, got " + cachedAfter.length + ": " + cachedPathsAfter.join(', '));
+
+            // Cleanup: delete the new file
+            void vscode.workspace.fs.delete(newFileUri);
+            await tests.waitForDiagnosticsChange(tests.filePathToUri('GscExcludePaths', 'scripts', 'included.gsc'), "delete included file");
+
+            // Should be back to 2
+            const cachedFinal = GscFiles.getCachedFiles([workspaceUri]);
+            assert.strictEqual(cachedFinal.length, 2, "Expected 2 cached files after cleanup, got " + cachedFinal.length);
+
+            LoggerOutput.log("[Tests][GscExcludePaths] create in included folder - done");
+
+            Issues.checkForNewError();
+        } catch (error) {
+            tests.printDebugInfoForError(error);
+        }
+    });
+
+
+    test('getFileData returns empty data for excluded file', async () => {
+        try {
+            LoggerOutput.log("[Tests][GscExcludePaths] getFileData excluded - start");
+
+            // Try to load an excluded file directly via getFileData
+            const excludedUri = tests.filePathToUri('GscExcludePaths', 'excluded_folder', 'should_be_excluded.gsc');
+            const gscFile = await GscFiles.getFileData(excludedUri, true, "test excluded file");
+
+            // The file should return with empty parse data (no functions)
+            assert.strictEqual(gscFile.data.functions.length, 0,
+                "Excluded file should have 0 functions but has " + gscFile.data.functions.length);
+
+            // And it should NOT be in the cache
+            const workspaceUri = tests.filePathToUri('GscExcludePaths');
+            const cachedFiles = GscFiles.getCachedFiles([workspaceUri]);
+            const cachedPaths = cachedFiles.map(f => vscode.workspace.asRelativePath(f.uri));
+            assert.ok(
+                !cachedPaths.some(p => p.includes('should_be_excluded.gsc')),
+                "should_be_excluded.gsc should NOT be in cache. Cached: " + cachedPaths.join(', ')
+            );
+
+            LoggerOutput.log("[Tests][GscExcludePaths] getFileData excluded - done");
+
+            Issues.checkForNewError();
+        } catch (error) {
+            tests.printDebugInfoForError(error);
+        }
+    });
+});

--- a/src/test/workspace/GscExcludePaths/.vscode/settings.json
+++ b/src/test/workspace/GscExcludePaths/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "gsc.game": "CoD2 MP",
+    "gsc.excludePaths": [
+        "**/excluded_folder/**",
+        "**/animtrees/**"
+    ]
+}

--- a/src/test/workspace/GscExcludePaths/animtrees/tree1.gsc
+++ b/src/test/workspace/GscExcludePaths/animtrees/tree1.gsc
@@ -1,0 +1,3 @@
+treeFunc() {
+    error_tree
+}

--- a/src/test/workspace/GscExcludePaths/excluded_folder/should_be_excluded.gsc
+++ b/src/test/workspace/GscExcludePaths/excluded_folder/should_be_excluded.gsc
@@ -1,0 +1,3 @@
+excludedFunc() {
+    error_excluded
+}

--- a/src/test/workspace/GscExcludePaths/scripts/also_included.gsc
+++ b/src/test/workspace/GscExcludePaths/scripts/also_included.gsc
@@ -1,0 +1,3 @@
+alsoIncludedFunc() {
+    error_also
+}

--- a/src/test/workspace/GscExcludePaths/scripts/included.gsc
+++ b/src/test/workspace/GscExcludePaths/scripts/included.gsc
@@ -1,0 +1,3 @@
+includedFunc() {
+    error_included
+}

--- a/src/test/workspace/vscode-cod-gsc-tests.code-workspace
+++ b/src/test/workspace/vscode-cod-gsc-tests.code-workspace
@@ -71,6 +71,10 @@
 		{
 			"name": "GscRename.3",
 			"path": "GscRename.3"
+		},
+		{
+			"name": "GscExcludePaths",
+			"path": "GscExcludePaths"
 		}
 	]
 }


### PR DESCRIPTION
Adds `gsc.excludePaths` 
 array of glob patterns to skip from parsing. Useful for workspaces that have large files that do not need to be parsed (animtrees, xanim, sound, fx) which otherwise produce hundreds of pointless diagnostics.

```json
{
    "gsc.excludePaths": ["**/animtrees/**", "**/sound/**"]
}
```

Matching files are dropped from the cache before parse, so they don't generate diagnostics or appear in completions.

Tests in `GscExcludePaths.test.ts` + a fixture workspace cover the matcher and end-to-end exclusion behaviour.
