### PR TITLE
Added CoD2 MP + CoD2x game variant now includes all cod2x functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,7 +128,8 @@
             "Universal game",
             "CoD2 MP",
             "CoD2 SP",
-            "CoD2 MP + zk_libcod"
+            "CoD2 MP + zk_libcod",
+            "CoD2 MP + CoD2x"
           ],
           "description": "The game for which the GSC files are intended. Each game has different syntax rules and list of predefined function.",
           "scope": "resource"

--- a/src/CodFunctions.ts
+++ b/src/CodFunctions.ts
@@ -7,7 +7,7 @@ export class CodFunctions {
 
     /**
      * Check if a function definition matches the given game.
-     * CoD2 MP + zk_libcod inherits all CoD2 MP functions.
+     * CoD2 MP + zk_libcod and CoD2 MP + CoD2x both inherit all CoD2 MP functions.
      */
     private static matchesGame(funcGames: string[], game: GscGame): boolean {
         if (funcGames.includes(game)) {
@@ -15,6 +15,10 @@ export class CodFunctions {
         }
         // CoD2 MP + zk_libcod includes all CoD2 MP functions
         if (game === GscGame.CoD2MPZkLibcod && funcGames.includes(GscGame.CoD2MP)) {
+            return true;
+        }
+        // CoD2 MP + CoD2x includes all CoD2 MP functions
+        if (game === GscGame.CoD2MPCod2x && funcGames.includes(GscGame.CoD2MP)) {
             return true;
         }
         return false;
@@ -49,12 +53,20 @@ export class CodFunctions {
 			return true;
 		};
 
-		// For CoD2 MP + zk_libcod, prefer exact game match over inherited CoD2 MP match.
-		// This ensures libcod-modified functions (with extra optional params) take priority.
+		// For extended variants, prefer exact game match over inherited CoD2 MP match.
+		// This ensures variant-specific overrides (e.g. extra optional params) take priority.
 		if (game === GscGame.CoD2MPZkLibcod) {
 			const exactMatch = defs.find(f =>
 				f.name.toLowerCase() === funcName &&
 				f.games.includes(GscGame.CoD2MPZkLibcod) &&
+				matchesCallOn(f)
+			);
+			if (exactMatch) { return exactMatch; }
+		}
+		if (game === GscGame.CoD2MPCod2x) {
+			const exactMatch = defs.find(f =>
+				f.name.toLowerCase() === funcName &&
+				f.games.includes(GscGame.CoD2MPCod2x) &&
 				matchesCallOn(f)
 			);
 			if (exactMatch) { return exactMatch; }

--- a/src/CodFunctionsDefinitions.ts
+++ b/src/CodFunctionsDefinitions.ts
@@ -24139,3 +24139,593 @@ defs.push(new CodFunction({
         }
     ]
 }));
+
+
+
+// =============================================================================
+// CoD2 MP + CoD2x functions
+// Source: https://github.com/callofduty2x/CoD2x (v1.4.6.8, 2026-04-07)
+// Docs:   https://cod2x.me/scripting/
+// =============================================================================
+
+// ---- Player methods (callOn = yes) ----
+
+defs.push(new CodFunction({
+    name: "getIp",
+    desc: "Returns the player's IP address as a dotted-decimal string (e.g. \"192.168.1.1\"). Useful for logging, banning, or streaming-overlay integrations.\n\n[📖 cod2x doc](https://cod2x.me/scripting/#getIp)",
+    example: "ip = self getIp();\nlogPrint(self.name + \" connected from \" + ip);",
+    callOn: "<player> A player entity",
+    returnType: "string",
+    module: "Player",
+    supportedAt: "",
+    games: ['CoD2 MP + CoD2x'],
+    parameters: [
+        {
+            name: "player",
+            desc: "A player entity",
+            type: "",
+            isOptional: false,
+            isVariableLength: false,
+            isCallOn: true
+        }
+    ]
+}));
+
+defs.push(new CodFunction({
+    name: "getHWID",
+    desc: "Returns the 32-character HWID2 hardware identifier of the player. Used for persistent player identification (e.g. ban systems, streaming overlays). Returns an empty string for bots.\n\n[📖 cod2x doc](https://cod2x.me/scripting/#getHWID)",
+    example: "hwid = self getHWID();\nif (isInBanList(hwid)) { kick(self.clientid); }",
+    callOn: "<player> A player entity",
+    returnType: "string",
+    module: "Player",
+    supportedAt: "",
+    games: ['CoD2 MP + CoD2x'],
+    parameters: [
+        {
+            name: "player",
+            desc: "A player entity",
+            type: "",
+            isOptional: false,
+            isVariableLength: false,
+            isCallOn: true
+        }
+    ]
+}));
+
+defs.push(new CodFunction({
+    name: "getCDKeyHash",
+    desc: "Returns the MD5 hash of the player's CD key as sent during connection. This is a client-supplied value and can be spoofed — always use getAuthorizationStatus() to verify whether the key is actually valid. Use as a fallback identifier when HWID is unavailable.\n\n[📖 cod2x doc](https://cod2x.me/scripting/#getCDKeyHash)",
+    example: "userId = self getCDKeyHash();",
+    callOn: "<player> A player entity",
+    returnType: "string",
+    module: "Player",
+    supportedAt: "",
+    games: ['CoD2 MP + CoD2x'],
+    parameters: [
+        {
+            name: "player",
+            desc: "A player entity",
+            type: "",
+            isOptional: false,
+            isVariableLength: false,
+            isCallOn: true
+        }
+    ]
+}));
+
+defs.push(new CodFunction({
+    name: "getAuthorizationStatus",
+    desc: "Returns the CD key authorization status string reported by the auth server during connection.\n\nPossible return values:\n- `\"KEY_IS_GOOD\"` — CD key is valid\n- `\"INVALID_CDKEY\"` — key is invalid or already in use by another player\n- `\"CLIENT_UNKNOWN_TO_AUTH\"` — client could not reach the auth server\n- `\"BANNED_CDKEY\"` — CD key is banned\n- `\"\"` (empty) — LAN, listen server, or sv_cracked 1\n\n[📖 cod2x doc](https://cod2x.me/scripting/#getAuthorizationStatus)",
+    example: "if (self getAuthorizationStatus() != \"KEY_IS_GOOD\") {\n    kick(self.clientid);\n}",
+    callOn: "<player> A player entity",
+    returnType: "string",
+    module: "Player",
+    supportedAt: "",
+    games: ['CoD2 MP + CoD2x'],
+    parameters: [
+        {
+            name: "player",
+            desc: "A player entity",
+            type: "",
+            isOptional: false,
+            isVariableLength: false,
+            isCallOn: true
+        }
+    ]
+}));
+
+defs.push(new CodFunction({
+    name: "getViewOrigin",
+    desc: "Returns the player's eye/view position as a 3D vector. Unlike getOrigin(), this accounts for stance height and lean offsets — use it for line-of-sight checks, distance-to-point calculations, and anything that needs the actual camera position.\n\n[📖 cod2x doc](https://cod2x.me/scripting/#getViewOrigin)",
+    example: "dist = distance(attacker getViewOrigin(), target.origin);",
+    callOn: "<player> A player entity",
+    returnType: "vector",
+    module: "Player",
+    supportedAt: "",
+    games: ['CoD2 MP + CoD2x'],
+    parameters: [
+        {
+            name: "player",
+            desc: "A player entity",
+            type: "",
+            isOptional: false,
+            isVariableLength: false,
+            isCallOn: true
+        }
+    ]
+}));
+
+defs.push(new CodFunction({
+    name: "getStance",
+    desc: "Returns the player's current stance as a string. Possible values: `\"stand\"`, `\"crouch\"`, `\"prone\"`.\n\n[📖 cod2x doc](https://cod2x.me/scripting/#getStance)",
+    example: "stance = self getStance();\nif (stance == \"prone\") { ... }",
+    callOn: "<player> A player entity",
+    returnType: "string",
+    module: "Player",
+    supportedAt: "",
+    games: ['CoD2 MP + CoD2x'],
+    parameters: [
+        {
+            name: "player",
+            desc: "A player entity",
+            type: "",
+            isOptional: false,
+            isVariableLength: false,
+            isCallOn: true
+        }
+    ]
+}));
+
+defs.push(new CodFunction({
+    name: "isUsingTurret",
+    desc: "Returns true if the player is currently operating a mounted MG turret, false otherwise. Useful to differentiate turret kills from regular bullet kills and to handle turret-related gameplay rules.\n\n[📖 cod2x doc](https://cod2x.me/scripting/#isUsingTurret)",
+    example: "if (self isUsingTurret()) {\n    // player is on a turret\n}",
+    callOn: "<player> A player entity",
+    returnType: "bool",
+    module: "Player",
+    supportedAt: "",
+    games: ['CoD2 MP + CoD2x'],
+    parameters: [
+        {
+            name: "player",
+            desc: "A player entity",
+            type: "",
+            isOptional: false,
+            isVariableLength: false,
+            isCallOn: true
+        }
+    ]
+}));
+
+defs.push(new CodFunction({
+    name: "matchPlayerGetData",
+    desc: "Returns a value from the match system's per-player data store for this player. Returns an empty string if the key does not exist.\n\nBuilt-in keys automatically populated by the match system: `\"key\"`, `\"uuid\"`, `\"name\"`, `\"team\"` (e.g. `\"team1\"`), `\"team_name\"`, `\"first_time\"` (ISO 8601 timestamp of first data save). Custom keys can be set via matchPlayerSetData().\n\n[📖 cod2x doc](https://cod2x.me/scripting/#matchPlayerGetData)",
+    example: "uuid = self matchPlayerGetData(\"uuid\");\nteamName = self matchPlayerGetData(\"team_name\");",
+    callOn: "<player> A player entity",
+    returnType: "string",
+    module: "Player",
+    supportedAt: "",
+    games: ['CoD2 MP + CoD2x'],
+    parameters: [
+        {
+            name: "player",
+            desc: "A player entity",
+            type: "",
+            isOptional: false,
+            isVariableLength: false,
+            isCallOn: true
+        },
+        {
+            name: "key",
+            desc: "The data key to retrieve",
+            type: "string",
+            isOptional: false,
+            isVariableLength: false,
+            isCallOn: false
+        }
+    ]
+}));
+
+defs.push(new CodFunction({
+    name: "matchPlayerSetData",
+    desc: "Stores key-value pairs in the match system's per-player data store for this player. Pass an even number of alternating key, value string arguments (minimum 2). Values can be retrieved with matchPlayerGetData().\n\n[📖 cod2x doc](https://cod2x.me/scripting/#matchPlayerSetData)",
+    example: "self matchPlayerSetData(\"kills\", \"\" + self.kills, \"deaths\", \"\" + self.deaths);",
+    callOn: "<player> A player entity",
+    returnType: "bool",
+    module: "Player",
+    supportedAt: "",
+    games: ['CoD2 MP + CoD2x'],
+    parameters: [
+        {
+            name: "player",
+            desc: "A player entity",
+            type: "",
+            isOptional: false,
+            isVariableLength: false,
+            isCallOn: true
+        },
+        {
+            name: "key",
+            desc: "First key string",
+            type: "string",
+            isOptional: false,
+            isVariableLength: false,
+            isCallOn: false
+        },
+        {
+            name: "value",
+            desc: "Value for the first key, followed by additional key-value pairs (must be an even total count)",
+            type: "string",
+            isOptional: false,
+            isVariableLength: true,
+            isCallOn: false
+        }
+    ]
+}));
+
+defs.push(new CodFunction({
+    name: "matchPlayerIsAllowed",
+    desc: "Returns true if the player has logged in with a valid match UUID (`/match login <uuid>`) that appears in the match's player whitelist, false otherwise. Returns false if the match system is not activated.\n\n[📖 cod2x doc](https://cod2x.me/scripting/#matchPlayerIsAllowed)",
+    example: "if (matchIsActivated() && !self matchPlayerIsAllowed()) {\n    kick(self.clientid);\n}",
+    callOn: "<player> A player entity",
+    returnType: "bool",
+    module: "Player",
+    supportedAt: "",
+    games: ['CoD2 MP + CoD2x'],
+    parameters: [
+        {
+            name: "player",
+            desc: "A player entity",
+            type: "",
+            isOptional: false,
+            isVariableLength: false,
+            isCallOn: true
+        }
+    ]
+}));
+
+// ---- Level / global functions (callOn = none) ----
+
+defs.push(new CodFunction({
+    name: "http_fetch",
+    desc: "Sends an asynchronous HTTP request. The game continues running while the request is in progress. On success, onDoneCallback is called with `(status:int, body:string, headers:array)`; on failure, onErrorCallback is called with `(error:string)`.\n\nHeaders string uses `\\r\\n` as separator (e.g. `\"Content-Type: application/json\\r\\nAccept: application/json\"`).\n\n[📖 cod2x doc](https://cod2x.me/scripting/#http_fetch)",
+    example: "http_fetch(\"https://api.example.com/score\", \"POST\", \"{\\\"kills\\\":5}\", \"Content-Type: application/json\", 5000, ::onDone, ::onError);\nonDone(status, body, headers) { if (status == 200) { ... } }\nonError(err) { logPrint(\"HTTP error: \" + err); }",
+    callOn: "",
+    returnType: "",
+    module: "Level",
+    supportedAt: "",
+    games: ['CoD2 MP + CoD2x'],
+    parameters: [
+        {
+            name: "url",
+            desc: "The URL to request",
+            type: "string",
+            isOptional: false,
+            isVariableLength: false,
+            isCallOn: false
+        },
+        {
+            name: "method",
+            desc: "HTTP method: \"GET\", \"POST\", \"PUT\", \"DELETE\", etc.",
+            type: "string",
+            isOptional: false,
+            isVariableLength: false,
+            isCallOn: false
+        },
+        {
+            name: "data",
+            desc: "Request body (use empty string \"\" for GET requests)",
+            type: "string",
+            isOptional: false,
+            isVariableLength: false,
+            isCallOn: false
+        },
+        {
+            name: "headers",
+            desc: "Additional HTTP headers separated by \\r\\n (use empty string \"\" for none)",
+            type: "string",
+            isOptional: false,
+            isVariableLength: false,
+            isCallOn: false
+        },
+        {
+            name: "timeout",
+            desc: "Request timeout in milliseconds",
+            type: "int",
+            isOptional: false,
+            isVariableLength: false,
+            isCallOn: false
+        },
+        {
+            name: "onDoneCallback",
+            desc: "Function called on success with (status:int, body:string, headers:array)",
+            type: "function",
+            isOptional: false,
+            isVariableLength: false,
+            isCallOn: false
+        },
+        {
+            name: "onErrorCallback",
+            desc: "Function called on failure with (error:string)",
+            type: "function",
+            isOptional: false,
+            isVariableLength: false,
+            isCallOn: false
+        }
+    ]
+}));
+
+defs.push(new CodFunction({
+    name: "websocket_connect",
+    desc: "Opens a WebSocket connection to the given URL. Returns a connection index (0–15) on success, or -1 if all slots are in use or an error occurs. Up to 16 simultaneous connections are supported.\n\nCallback signatures:\n- `onConnectCallback()` — called when the connection is established\n- `onMessageCallback(message:string)` — called for each incoming text frame\n- `onCloseCallback(isClosedByRemote:bool, isFullyDisconnected:bool)` — called when the connection closes\n- `onErrorCallback(error:string)` — called on connection errors\n\nConnections are automatically closed on map change. The connection index must be stored to use websocket_sendText() and websocket_close().\n\n[📖 cod2x doc](https://cod2x.me/scripting/#websocket_connect)",
+    example: "id = websocket_connect(\"wss://api.example.com/ws\", \"\", ::onConnect, ::onMsg, ::onClose, ::onError);\nonMsg(msg) { logPrint(\"WS received: \" + msg); }",
+    callOn: "",
+    returnType: "int",
+    module: "Level",
+    supportedAt: "",
+    games: ['CoD2 MP + CoD2x'],
+    parameters: [
+        {
+            name: "url",
+            desc: "WebSocket URL to connect to (ws:// or wss://)",
+            type: "string",
+            isOptional: false,
+            isVariableLength: false,
+            isCallOn: false
+        },
+        {
+            name: "headers",
+            desc: "Optional extra HTTP headers for the handshake, separated by \\r\\n (use empty string \"\" for none)",
+            type: "string",
+            isOptional: false,
+            isVariableLength: false,
+            isCallOn: false
+        },
+        {
+            name: "onConnectCallback",
+            desc: "Called when connection opens (no parameters)",
+            type: "function",
+            isOptional: false,
+            isVariableLength: false,
+            isCallOn: false
+        },
+        {
+            name: "onMessageCallback",
+            desc: "Called when a text message is received (message:string)",
+            type: "function",
+            isOptional: false,
+            isVariableLength: false,
+            isCallOn: false
+        },
+        {
+            name: "onCloseCallback",
+            desc: "Called when connection closes (isClosedByRemote:bool, isFullyDisconnected:bool)",
+            type: "function",
+            isOptional: false,
+            isVariableLength: false,
+            isCallOn: false
+        },
+        {
+            name: "onErrorCallback",
+            desc: "Called on error (error:string)",
+            type: "function",
+            isOptional: false,
+            isVariableLength: false,
+            isCallOn: false
+        },
+        {
+            name: "reconnectDelayMs",
+            desc: "Milliseconds to wait before reconnecting after a disconnect (default: 2000)",
+            type: "int",
+            isOptional: true,
+            isVariableLength: false,
+            isCallOn: false
+        },
+        {
+            name: "pingIntervalMs",
+            desc: "Milliseconds between keep-alive pings (default: 15000; set to 0 to disable)",
+            type: "int",
+            isOptional: true,
+            isVariableLength: false,
+            isCallOn: false
+        }
+    ]
+}));
+
+defs.push(new CodFunction({
+    name: "websocket_sendText",
+    desc: "Sends a UTF-8 text frame over the WebSocket connection identified by connectionId. Returns true if the message was queued for sending, false if the connection slot is invalid or not connected.\n\n[📖 cod2x doc](https://cod2x.me/scripting/#websocket_sendText)",
+    example: "if (!websocket_sendText(id, \"ping\")) {\n    logPrint(\"WS send failed\");\n}",
+    callOn: "",
+    returnType: "bool",
+    module: "Level",
+    supportedAt: "",
+    games: ['CoD2 MP + CoD2x'],
+    parameters: [
+        {
+            name: "connectionId",
+            desc: "Connection index returned by websocket_connect",
+            type: "int",
+            isOptional: false,
+            isVariableLength: false,
+            isCallOn: false
+        },
+        {
+            name: "message",
+            desc: "UTF-8 text message to send",
+            type: "string",
+            isOptional: false,
+            isVariableLength: false,
+            isCallOn: false
+        }
+    ]
+}));
+
+defs.push(new CodFunction({
+    name: "websocket_close",
+    desc: "Requests a graceful close of the WebSocket connection at the given index. Returns true if the close was requested successfully, false if the index is invalid or the connection is already gone.\n\n[📖 cod2x doc](https://cod2x.me/scripting/#websocket_close)",
+    example: "websocket_close(id);",
+    callOn: "",
+    returnType: "bool",
+    module: "Level",
+    supportedAt: "",
+    games: ['CoD2 MP + CoD2x'],
+    parameters: [
+        {
+            name: "connectionId",
+            desc: "Connection index returned by websocket_connect",
+            type: "int",
+            isOptional: false,
+            isVariableLength: false,
+            isCallOn: false
+        }
+    ]
+}));
+
+defs.push(new CodFunction({
+    name: "matchUploadData",
+    desc: "Uploads the current match progress data (global + per-player) to the match server. Returns true if the upload request was sent, false if the match system is not activated.\n\nThe optional callbacks are invoked asynchronously: onDoneCallback is called with no arguments on success; onErrorCallback is called with (error:string) on failure.\n\n[📖 cod2x doc](https://cod2x.me/scripting/#matchUploadData)",
+    example: "matchUploadData(::onUploadDone, ::onUploadError);\nonUploadDone() { logPrint(\"Match data uploaded.\"); }\nonUploadError(err) { logPrint(\"Upload failed: \" + err); }",
+    callOn: "",
+    returnType: "bool",
+    module: "Level",
+    supportedAt: "",
+    games: ['CoD2 MP + CoD2x'],
+    parameters: [
+        {
+            name: "onDoneCallback",
+            desc: "Optional function called with no parameters on success",
+            type: "function",
+            isOptional: true,
+            isVariableLength: false,
+            isCallOn: false
+        },
+        {
+            name: "onErrorCallback",
+            desc: "Optional function called with (error:string) on failure",
+            type: "function",
+            isOptional: true,
+            isVariableLength: false,
+            isCallOn: false
+        }
+    ]
+}));
+
+defs.push(new CodFunction({
+    name: "matchSetData",
+    desc: "Stores key-value pairs in the match system's global data store. Pass an even number of alternating key, value string arguments (minimum 2). Values can be retrieved with matchGetData().\n\nNote: built-in keys such as `\"match_id\"`, `\"team1_id\"`, `\"team2_id\"`, `\"team1_name\"`, `\"team2_name\"` are auto-populated from the match data and will be overwritten on the next read cycle.\n\n[📖 cod2x doc](https://cod2x.me/scripting/#matchSetData)",
+    example: "matchSetData(\"team1_score\", \"\" + level.team1Score, \"team2_score\", \"\" + level.team2Score);",
+    callOn: "",
+    returnType: "bool",
+    module: "Level",
+    supportedAt: "",
+    games: ['CoD2 MP + CoD2x'],
+    parameters: [
+        {
+            name: "key",
+            desc: "First key string",
+            type: "string",
+            isOptional: false,
+            isVariableLength: false,
+            isCallOn: false
+        },
+        {
+            name: "value",
+            desc: "Value for the first key, followed by additional key-value pairs (must be an even total count)",
+            type: "string",
+            isOptional: false,
+            isVariableLength: true,
+            isCallOn: false
+        }
+    ]
+}));
+
+defs.push(new CodFunction({
+    name: "matchGetData",
+    desc: "Returns the global match data value for the given key. Returns an empty string if the key does not exist.\n\nBuilt-in keys auto-populated from match configuration: `\"match_id\"`, `\"team1_id\"`, `\"team2_id\"`, `\"team1_name\"`, `\"team2_name\"`.\n\nDynamic array keys (return arrays): `\"team1_player_uuids\"`, `\"team2_player_uuids\"`, `\"team1_player_names\"`, `\"team2_player_names\"`, `\"maps\"`.\n\n[📖 cod2x doc](https://cod2x.me/scripting/#matchGetData)",
+    example: "format = matchGetData(\"format\");\nmaps = matchGetData(\"maps\");\nteam1UUIDs = matchGetData(\"team1_player_uuids\");",
+    callOn: "",
+    returnType: "string",
+    module: "Level",
+    supportedAt: "",
+    games: ['CoD2 MP + CoD2x'],
+    parameters: [
+        {
+            name: "key",
+            desc: "The data key to retrieve",
+            type: "string",
+            isOptional: false,
+            isVariableLength: false,
+            isCallOn: false
+        }
+    ]
+}));
+
+defs.push(new CodFunction({
+    name: "matchRedownloadData",
+    desc: "Triggers a fresh download of match configuration data from the match server, updating all match fields (teams, players, maps, etc.). Returns true if the request was sent successfully, false on failure.\n\n[📖 cod2x doc](https://cod2x.me/scripting/#matchRedownloadData)",
+    example: "matchRedownloadData();",
+    callOn: "",
+    returnType: "bool",
+    module: "Level",
+    supportedAt: "",
+    games: ['CoD2 MP + CoD2x'],
+    parameters: []
+}));
+
+defs.push(new CodFunction({
+    name: "matchClearData",
+    desc: "Clears all data in both the global match data store and all per-player data stores. Always returns true. Call at the start of a new round to reset tracked statistics.\n\n[📖 cod2x doc](https://cod2x.me/scripting/#matchClearData)",
+    example: "matchClearData();",
+    callOn: "",
+    returnType: "bool",
+    module: "Level",
+    supportedAt: "",
+    games: ['CoD2 MP + CoD2x'],
+    parameters: []
+}));
+
+defs.push(new CodFunction({
+    name: "matchIsActivated",
+    desc: "Returns true if the CoD2x match system is currently active (i.e. a match has been configured and loaded from the match server), false otherwise. Use this to guard all match-system calls so they don't run on regular public servers.\n\n[📖 cod2x doc](https://cod2x.me/scripting/#matchIsActivated)",
+    example: "if (matchIsActivated()) {\n    teamName = self matchPlayerGetData(\"team_name\");\n}",
+    callOn: "",
+    returnType: "bool",
+    module: "Level",
+    supportedAt: "",
+    games: ['CoD2 MP + CoD2x'],
+    parameters: []
+}));
+
+defs.push(new CodFunction({
+    name: "matchCancel",
+    desc: "Cancels the ongoing match and triggers a fast_restart. If a reason string is provided it is sent to the match server as an error message. Returns true if the match system is activated and the cancel was processed, false otherwise.\n\n[📖 cod2x doc](https://cod2x.me/scripting/#matchCancel)",
+    example: "maps = matchGetData(\"maps\");\nif (!maps.size) {\n    matchCancel(\"No maps configured for this match.\");\n}",
+    callOn: "",
+    returnType: "bool",
+    module: "Level",
+    supportedAt: "",
+    games: ['CoD2 MP + CoD2x'],
+    parameters: [
+        {
+            name: "reason",
+            desc: "Optional cancellation reason sent to the match server as an error message",
+            type: "string",
+            isOptional: true,
+            isVariableLength: false,
+            isCallOn: false
+        }
+    ]
+}));
+
+defs.push(new CodFunction({
+    name: "matchFinish",
+    desc: "Ends the match cleanly: kicks all players, cancels the match on the match server, then performs a fast_restart. Returns true if the match system is activated, false otherwise.\n\n[📖 cod2x doc](https://cod2x.me/scripting/#matchFinish)",
+    example: "if (level.winnerTeam != \"\") {\n    matchFinish();\n}",
+    callOn: "",
+    returnType: "bool",
+    module: "Level",
+    supportedAt: "",
+    games: ['CoD2 MP + CoD2x'],
+    parameters: []
+}));

--- a/src/GscConfig.ts
+++ b/src/GscConfig.ts
@@ -12,6 +12,7 @@ export enum GscGame {
 	CoD2SP = "CoD2 SP",
 	CoD2MP = "CoD2 MP",
 	CoD2MPZkLibcod = "CoD2 MP + zk_libcod",
+	CoD2MPCod2x = "CoD2 MP + CoD2x",
 }
 
 // These must match with package.json settings
@@ -112,6 +113,19 @@ export class GscConfig {
 			}],
 			[GscGame.CoD2MPZkLibcod, {
 				game: GscGame.CoD2MPZkLibcod,
+				includeFileItself: false,
+				globalVariables: false,
+				developerBlocks: true,
+				developerBlocksRecursive: false,
+				duplicateFunctionDefinitions: false,
+				foreach: false,
+				doWhile: false,
+				arrayInitializer: false,
+				ternary: false,
+				cvarString: false
+			}],
+			[GscGame.CoD2MPCod2x, {
+				game: GscGame.CoD2MPCod2x,
 				includeFileItself: false,
 				globalVariables: false,
 				developerBlocks: true,
@@ -336,7 +350,8 @@ export class GscConfig {
 			{ label: GscGame.UniversalGame },
 			{ label: GscGame.CoD2SP },
 			{ label: GscGame.CoD2MP },
-			{ label: GscGame.CoD2MPZkLibcod }
+			{ label: GscGame.CoD2MPZkLibcod },
+			{ label: GscGame.CoD2MPCod2x }
 		];
 	
 		const selection = await vscode.window.showQuickPick(options, {

--- a/src/test/workspace/GscAll.CoD2MPCod2x/.vscode/settings.json
+++ b/src/test/workspace/GscAll.CoD2MPCod2x/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "gsc.game": "CoD2 MP + CoD2x"
+}

--- a/src/test/workspace/GscAll.CoD2MPCod2x/cod2xFunctions.gsc
+++ b/src/test/workspace/GscAll.CoD2MPCod2x/cod2xFunctions.gsc
@@ -1,0 +1,39 @@
+// =============================================================================
+// Every CoD2x function called with the correct callOn shape and the minimum
+// required argument count. Source of truth: src/CodFunctionsDefinitions.ts.
+//
+// Expected diagnostics: 0.
+//
+// If this file produces any diagnostic, a cod2x entry has regressed (wrong
+// callOn flag, wrong required-arg count, or the function got renamed). The
+// failing diagnostic message will name the culprit.
+// =============================================================================
+
+main()
+{
+    // ---- Player methods (10 functions) ----
+    self getIp();
+    self getHWID();
+    self getCDKeyHash();
+    self getAuthorizationStatus();
+    self getViewOrigin();
+    self getStance();
+    self isUsingTurret();
+    self matchPlayerGetData(1);
+    self matchPlayerSetData(1, 1);
+    self matchPlayerIsAllowed();
+
+    // ---- Level functions (12 functions) ----
+    http_fetch(1, 1, 1, 1, 1, 1, 1);
+    websocket_connect(1, 1, 1, 1, 1, 1);
+    websocket_sendText(1, 1);
+    websocket_close(1);
+    matchUploadData();
+    matchSetData(1, 1);
+    matchGetData(1);
+    matchRedownloadData();
+    matchClearData();
+    matchIsActivated();
+    matchCancel();
+    matchFinish();
+}

--- a/src/test/workspace/GscAll.CoD2MPCod2x/stockInherited.gsc
+++ b/src/test/workspace/GscAll.CoD2MPCod2x/stockInherited.gsc
@@ -1,0 +1,10 @@
+// Stock CoD2 MP functions must remain resolvable under the CoD2x variant.
+// Expected diagnostics: 0.
+
+main()
+{
+    ent = spawn("script_model", (0, 0, 0));
+    self iPrintLn("hello");
+    self setModel("xmodel/player_usa_ranger_assault");
+    wait 1;
+}

--- a/src/test/workspace/GscAll_CoD2MPCod2x.test.ts
+++ b/src/test/workspace/GscAll_CoD2MPCod2x.test.ts
@@ -1,0 +1,46 @@
+import assert from 'assert';
+import * as tests from '../Tests.test';
+import { CodFunctions } from '../../CodFunctions';
+import { GscGame } from '../../GscConfig';
+
+
+/*
+These tests depend on pre-created files in ./src/test/workspace/GscAll.CoD2MPCod2x
+These files are copied into temp folder (configured in .vscode-test.mjs).
+
+The CoD2 MP + CoD2x variant inherits all stock CoD2 MP functions and adds
+22 CoD2x-specific functions (player methods + level functions).
+*/
+
+suite('GscAll.CoD2MPCod2x', () => {
+
+    setup(async () => {
+        await tests.activateExtension();
+    });
+
+
+    test('GscAll.CoD2MPCod2x.inheritsStockCoD2MP', () => {
+        // The variant must include both stock CoD2 MP functions and CoD2x additions.
+        const stock = CodFunctions.getDefinitions(GscGame.CoD2MP).length;
+        const cod2x = CodFunctions.getDefinitions(GscGame.CoD2MPCod2x).length;
+        assert.ok(cod2x > stock, `CoD2x variant (${cod2x}) should include strictly more functions than stock CoD2 MP (${stock})`);
+    });
+
+
+    test('GscAll.CoD2MPCod2x.cod2xFunctions', async () => {
+        // Exercises every CoD2x function with the correct callOn shape and the
+        // minimum required argument count.
+        const gsc = await tests.loadGscFile(['GscAll.CoD2MPCod2x', 'cod2xFunctions.gsc']);
+        assert.strictEqual(gsc.diagnostics.length, 0, "Expected zero diagnostics, got: " +
+            gsc.diagnostics.map(d => d.message).join(" | "));
+    });
+
+
+    test('GscAll.CoD2MPCod2x.stockInherited', async () => {
+        // Stock CoD2 MP functions must remain resolvable under the CoD2x variant.
+        const gsc = await tests.loadGscFile(['GscAll.CoD2MPCod2x', 'stockInherited.gsc']);
+        assert.strictEqual(gsc.diagnostics.length, 0, "Expected zero diagnostics, got: " +
+            gsc.diagnostics.map(d => d.message).join(" | "));
+    });
+
+});

--- a/src/test/workspace/vscode-cod-gsc-tests.code-workspace
+++ b/src/test/workspace/vscode-cod-gsc-tests.code-workspace
@@ -13,6 +13,10 @@
 			"path": "GscAll.CoD2MPZkLibcod"
 		},
 		{
+			"name": "GscAll.CoD2MPCod2x",
+			"path": "GscAll.CoD2MPCod2x"
+		},
+		{
 			"name": "GscAll.UniversalGame",
 			"path": "GscAll.UniversalGame"
 		},


### PR DESCRIPTION
## Summary

Adds **CoD2 MP + CoD2x** as a new game variant, covering the 22 GSC functions uptil [CoD2x v1.4.6.8](https://github.com/callofduty2x/CoD2x) (cod2x.me).

- **10 player methods** — `getIp`, `getHWID`, `getCDKeyHash`, `getAuthorizationStatus`, `getViewOrigin`, `getStance`, `isUsingTurret`, `matchPlayerGetData`, `matchPlayerSetData`, `matchPlayerIsAllowed`
- **12 level functions** — `http_fetch`, `websocket_connect`, `websocket_sendText`, `websocket_close`, `matchUploadData`, `matchSetData`, `matchGetData`, `matchRedownloadData`, `matchClearData`, `matchIsActivated`, `matchCancel`, `matchFinish`

All entries include descriptions sourced from the CoD2x C++ source and real usage in [zPAM3](https://github.com/eyza-cod2/zpam3), with links to `https://cod2x.me/scripting/#<functionName>`.
